### PR TITLE
Feature: cassettes modification

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,27 @@ To mock the server's responses simply change `VcrMode::Record` to
 made, intercept it, and return the saved response.
 
 
+### Modify Recorded Content
+
+It is possible to modify data before writing to your cassette files. This is useful while working with sensitive or dynamic data.
+
+```rust
+VcrMiddleware::new(VcrMode::Record, path).await?
+    .with_modify_request(|req| {
+        req
+            .headers
+            .entry("session-key".into())
+            .and_modify(|val| *val = vec!["...(erased)...".into()]);
+    })
+    .with_modify_response(|res| {
+        res
+            .headers
+            .entry("Set-Cookie".into())
+            .and_modify(|val| *val = vec!["...(erased)...".into()]);
+    });
+```
+
+
 ## License
 
 All source code is licensed under the terms of the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,8 +127,8 @@ type Session = (Vec<VcrRequest>, Vec<VcrResponse>);
 static CASSETTES: OnceCell<RwLock<HashMap<PathBuf, RwLock::<Option<Session>>>>>
     = OnceCell::new();
 
-pub type RequestModifier = dyn Fn(&mut VcrRequest) + Send + Sync + 'static;
-pub type ResponseModifier = dyn Fn(&mut VcrResponse) + Send + Sync + 'static;
+type RequestModifier = dyn Fn(&mut VcrRequest) + Send + Sync + 'static;
+type ResponseModifier = dyn Fn(&mut VcrResponse) + Send + Sync + 'static;
 
 /// Record and playback HTTP sessions.
 ///
@@ -314,6 +314,7 @@ pub enum VcrMode {
     Replay,
 }
 
+/// Request to be recorded in cassettes.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct VcrRequest {
     pub method: Method,
@@ -378,6 +379,7 @@ impl From<VcrRequest> for Request {
     }
 }
 
+/// Response to be recorded in cassettes.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct VcrResponse {
     pub status: StatusCode,

--- a/test-sessions/simple.yml
+++ b/test-sessions/simple.yml
@@ -20,6 +20,8 @@
     headers:
       x-some-header:
         - another hello
+      secret-header:
+        - (secret)
     body: ""
 - Response:
     status: 200
@@ -41,6 +43,8 @@
         - application/octet-stream
       x-some-header:
         - another hello
+      session-key:
+        - 00112233445566778899AABBCCDDEEFF
     body: ""
 - Response:
     status: 200
@@ -52,4 +56,7 @@
         - "Fri, 28 May 2021 00:44:58 GMT"
       x-some-header:
         - another goodbye
+      Set-Cookie:
+        - cookie1=val1; Expires=date1
+        - cookie2=val2; Expires=date2
     body: And Another Response


### PR DESCRIPTION
This crate is helpful, thanks @rjframe . However, we still need a way to hide sensitive data before saving them to cassettes. Such feature would be useful while testing some private API. This PR exposes the `VcrRequest` and `VcrResponse`, and provide methods to modify the content to save.